### PR TITLE
:bug: fix: Troca a importação de load_dotenv por dotenv_values

### DIFF
--- a/digithemis/src/config/conexao_db.py
+++ b/digithemis/src/config/conexao_db.py
@@ -1,9 +1,9 @@
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 
-env = load_dotenv()
+env = dotenv_values()
 
 
 class ConexaoDB:


### PR DESCRIPTION
Corrige a importação de load_dotenv para dotenv_values no arquivo de conexão com o banco de dados no modulo **'config'**.